### PR TITLE
Add comprehensive README and CLAUDE.md documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# CLAUDE.md
+
+Project guidance for Claude Code sessions working on Sparkdown.
+
+## Project Overview
+
+Sparkdown is a semantic markdown processor in Rust. It parses markdown with semantic annotations and renders to HTML+RDFa, JSON-LD, or Turtle. The key architectural concept is the **semantic overlay** — separating clean markdown from RDF metadata using sidecar files (`.sparkdown-sem`).
+
+## Build & Test Commands
+
+```bash
+cargo build                    # build all crates
+cargo test                     # run all tests
+cargo test -p sparkdown-core   # test a specific crate
+cargo run -p sparkdown-cli -- <COMMAND>  # run the CLI
+```
+
+All five crates must compile and pass tests before committing.
+
+## Workspace Structure
+
+```
+crates/
+  sparkdown-core/       # Parsing, AST, annotations, frontmatter, prefix maps
+  sparkdown-ontology/   # Ontology registry (schema.org, Dublin Core, FOAF, sd:)
+  sparkdown-render/     # Renderers: HTML+RDFa, JSON-LD, Turtle
+  sparkdown-overlay/    # Semantic overlay: graph, anchors, sidecar, sync engine
+  sparkdown-cli/        # CLI (clap-based): render, validate, extract, init, overlay
+```
+
+## Code Conventions
+
+- Rust 2024 edition.
+- Use `thiserror` for library error types in crates; `anyhow` for CLI error handling.
+- Each crate exposes a public API via `lib.rs`; keep internal modules private where possible.
+- Serde derives for types that cross serialization boundaries.
+- Tests live in `#[cfg(test)] mod tests` blocks within source files, plus integration tests in `tests/`.
+
+## Key Concepts
+
+- **Sidecar file** (`.sparkdown-sem`): Turtle-inspired format storing semantic entities with byte-span anchors mapping them back to the markdown source.
+- **Anchor staleness**: When markdown is edited, the sync engine (`sparkdown-overlay/src/sync.rs`) diffs the old and new text, adjusts anchors, and marks entities as stale if their anchored text changed.
+- **Three modes**: Legacy (inline annotations only), Overlay (sidecar only), Hybrid (both). Mode is declared in YAML frontmatter.
+- **Prefix maps**: Namespace prefixes (e.g., `schema:`, `dc:`) are declared in frontmatter and resolved by `sparkdown-core`.
+
+## Design Spec
+
+The full architecture spec lives at `docs/superpowers/specs/2026-03-21-semantic-overlay-design.md`.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,108 @@
-# sparkdown
+# Sparkdown
+
+A semantic markdown processor written in Rust. Sparkdown lets authors write clean, readable markdown while maintaining rich semantic annotations (RDF) in a separate overlay layer — keeping documents human-friendly and machine-readable at the same time.
+
+## Key Features
+
+- **Semantic Overlay Architecture** — Separates content from semantics using a three-layer design: Markdown layer (clean documents), Semantic layer (RDF metadata in `.sparkdown-sem` sidecar files), and Mapping layer (bidirectional index connecting the two).
+- **Multiple Output Formats** — Render to HTML+RDFa, JSON-LD, or Turtle.
+- **Built-in Ontology Support** — Ships with schema.org, Dublin Core, FOAF, and a custom `sd:` vocabulary. Extensible ontology registry.
+- **AI-Agent Friendly** — Designed for collaborative authoring: humans write markdown, AI agents add semantic annotations via sidecar files, and both can review or adjust without cluttering the source.
+- **Overlay Sync** — Intelligent diff-based sync engine that tracks anchor staleness and adjusts byte-span mappings when the markdown changes.
+- **CLI Tooling** — Full-featured command-line interface for rendering, validation, extraction, and overlay management.
+
+## Architecture
+
+Sparkdown is organized as a Rust workspace with five crates:
+
+| Crate | Purpose |
+|---|---|
+| `sparkdown-core` | Parsing pipeline (frontmatter → preprocess → pulldown-cmark → postprocess), AST types, annotation parsing, prefix maps |
+| `sparkdown-ontology` | Ontology registry and validation, builtin providers |
+| `sparkdown-render` | Output renderers: HTML+RDFa, JSON-LD, Turtle |
+| `sparkdown-overlay` | Semantic overlay implementation: graph, anchoring, sidecar file parsing, sync engine |
+| `sparkdown-cli` | Command-line interface built with clap |
+
+## Getting Started
+
+### Prerequisites
+
+- [Rust](https://www.rust-lang.org/tools/install) (edition 2024)
+
+### Build
+
+```bash
+cargo build
+cargo build --release  # optimized build
+```
+
+### Test
+
+```bash
+cargo test               # run all tests
+cargo test -p sparkdown-core  # test a specific crate
+```
+
+### Run
+
+```bash
+cargo run -p sparkdown-cli -- <COMMAND>
+```
+
+## CLI Usage
+
+```
+sparkdown <COMMAND>
+
+Commands:
+  render     Render a document to an output format (html, jsonld, turtle)
+  validate   Validate semantic annotations
+  extract    Extract RDF triples (turtle or jsonld)
+  init       Initialize a new document with frontmatter template
+  overlay    Manage semantic overlay sidecar files
+```
+
+### Examples
+
+```bash
+# Render a document to HTML
+sparkdown render doc.md --format html
+
+# Validate annotations
+sparkdown validate doc.md
+
+# Extract RDF triples as Turtle
+sparkdown extract doc.md --format turtle
+
+# Initialize a new article
+sparkdown init my-article.md --doc-type article
+
+# Create a sidecar overlay file
+sparkdown overlay init doc.md
+
+# Sync overlay after markdown edits
+sparkdown overlay sync doc.md
+
+# Check overlay status (stale/detached entities)
+sparkdown overlay status doc.md
+
+# Export sidecar to valid Turtle
+sparkdown overlay export doc.md
+
+# Migrate inline annotations to sidecar
+sparkdown overlay import doc.md
+```
+
+## Technologies
+
+- **Rust** (2024 edition) — core language
+- **pulldown-cmark** — CommonMark parsing
+- **oxrdf** — RDF data model
+- **clap** — CLI argument parsing
+- **serde / serde_json / serde_yaml_ng** — serialization
+- **similar** — diffing for overlay sync
+- **thiserror / anyhow** — error handling
+
+## License
+
+Apache 2.0 — see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary

This PR adds comprehensive project documentation to establish clear guidance for developers and users of Sparkdown. Two new documentation files have been created to serve different audiences: a user-facing README and a developer-focused CLAUDE.md guide.

## Key Changes

- **README.md** — Complete project documentation including:
  - Project description and key features overview
  - Architecture overview with workspace crate breakdown
  - Getting started guide (prerequisites, build, test, run instructions)
  - Full CLI usage documentation with command examples
  - Technology stack and license information

- **CLAUDE.md** — Developer guidance document for Claude Code sessions including:
  - Project overview and core concepts
  - Build and test commands for quick reference
  - Workspace structure and file organization
  - Code conventions (Rust 2024 edition, error handling patterns, module organization)
  - Key architectural concepts (sidecar files, anchor staleness, semantic modes, prefix maps)
  - Reference to the full design specification

## Notable Details

- Documentation reflects the complete five-crate workspace architecture (sparkdown-core, sparkdown-ontology, sparkdown-render, sparkdown-overlay, sparkdown-cli)
- CLI examples cover all major commands: render, validate, extract, init, and overlay management
- CLAUDE.md provides actionable guidance for maintaining code quality (all crates must compile and pass tests before committing)
- Both documents establish the semantic overlay architecture as the central design concept

https://claude.ai/code/session_019Dy2hPcapvFqD7hVF4vSYa