### PR TITLE
Add Sparkdown Studio documentation and dev setup guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,9 @@ crates/
   sparkdown-render/     # Renderers: HTML+RDFa, JSON-LD, Turtle
   sparkdown-overlay/    # Semantic overlay: graph, anchors, sidecar, sync engine
   sparkdown-cli/        # CLI (clap-based): render, validate, extract, init, overlay
+studio/
+  src/                  # Svelte 5 frontend (components, stores, editor extensions)
+  src-tauri/            # Tauri 2 Rust backend (session actors, IPC commands, events)
 ```
 
 ## Code Conventions
@@ -42,6 +45,20 @@ crates/
 - **Anchor staleness**: When markdown is edited, the sync engine (`sparkdown-overlay/src/sync.rs`) diffs the old and new text, adjusts anchors, and marks entities as stale if their anchored text changed.
 - **Three modes**: Legacy (inline annotations only), Overlay (sidecar only), Hybrid (both). Mode is declared in YAML frontmatter.
 - **Prefix maps**: Namespace prefixes (e.g., `schema:`, `dc:`) are declared in frontmatter and resolved by `sparkdown-core`.
+
+## Studio Dev Mode
+
+Sparkdown Studio is a Tauri 2 desktop app (Svelte 5 + CodeMirror 6 frontend). The studio crate depends on all five sparkdown crates.
+
+```bash
+cd studio
+pnpm install          # install frontend dependencies
+cargo tauri dev       # start Vite dev server (localhost:1420) + Tauri desktop window
+```
+
+For frontend-only work: `pnpm dev` runs the Vite server standalone on `http://localhost:1420`.
+
+Key config: `studio/src-tauri/tauri.conf.json` defines the dev URL, build commands, and window settings.
 
 ## Design Spec
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,37 @@ sparkdown overlay export doc.md
 sparkdown overlay import doc.md
 ```
 
+## Sparkdown Studio
+
+Sparkdown Studio is a visual semantic editing desktop application built with [Tauri 2](https://tauri.app/) (Rust backend) and [Svelte 5](https://svelte.dev/) (frontend). It provides a CodeMirror 6 markdown editor with semantic gutter annotations, entity decorations, and overlay sync — all powered by the core Sparkdown crates.
+
+### Prerequisites
+
+- [Rust](https://www.rust-lang.org/tools/install) (edition 2024)
+- [Node.js](https://nodejs.org/) (LTS recommended)
+- [pnpm](https://pnpm.io/)
+- [Tauri 2 system dependencies](https://v2.tauri.app/start/prerequisites/) (platform-specific — see Tauri docs)
+
+### Running in Dev Mode
+
+```bash
+cd studio
+pnpm install          # install frontend dependencies
+cargo tauri dev       # start the dev server and desktop app
+```
+
+`cargo tauri dev` will:
+1. Start the Vite dev server on `http://localhost:1420` with hot reload
+2. Build the Rust backend (which depends on all five Sparkdown crates)
+3. Launch the Tauri desktop window connected to the dev server
+
+You can also run the frontend alone for UI work:
+
+```bash
+cd studio
+pnpm dev              # Vite dev server only, at http://localhost:1420
+```
+
 ## Technologies
 
 - **Rust** (2024 edition) — core language
@@ -102,6 +133,10 @@ sparkdown overlay import doc.md
 - **serde / serde_json / serde_yaml_ng** — serialization
 - **similar** — diffing for overlay sync
 - **thiserror / anyhow** — error handling
+- **Tauri 2** — cross-platform desktop framework (Studio)
+- **Svelte 5** — reactive frontend framework (Studio)
+- **Vite** — frontend dev server and build tool (Studio)
+- **CodeMirror 6** — extensible code editor (Studio)
 
 ## License
 


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation for Sparkdown Studio, a new visual semantic editing desktop application built with Tauri 2 and Svelte 5. The changes include setup instructions, development workflow guidance, and updated architecture documentation.

## Key Changes
- **README.md**: Added "Sparkdown Studio" section with:
  - Overview of the application stack (Tauri 2 + Svelte 5 + CodeMirror 6)
  - Prerequisites (Rust, Node.js, pnpm, Tauri dependencies)
  - Dev mode setup instructions (`cargo tauri dev`)
  - Explanation of what the dev server does (Vite hot reload, Rust backend build, Tauri window launch)
  - Alternative frontend-only workflow (`pnpm dev`)
  - Updated Technologies section with Studio-specific dependencies (Tauri 2, Svelte 5, Vite, CodeMirror 6)

- **CLAUDE.md**: Updated project structure and developer guide with:
  - New `studio/` directory structure showing Svelte frontend (`src/`) and Tauri backend (`src-tauri/`)
  - "Studio Dev Mode" section with quick-start commands and workflow notes
  - Reference to key config file (`studio/src-tauri/tauri.conf.json`)

## Notable Details
- Documentation emphasizes the dual-mode development workflow: full app via `cargo tauri dev` or frontend-only via `pnpm dev`
- Clearly explains the dependency chain: Studio crate depends on all five core Sparkdown crates
- Provides platform-specific guidance by linking to Tauri 2 prerequisites documentation

https://claude.ai/code/session_016rnLnDksJMznyFAQYMNRYb